### PR TITLE
chore: adjust eslint-config to use eslint-config-prettier package and necessary rules to comply with the projects [MT-6078]

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,11 @@
+# This file is used by [direnv](https://direnv.net/), as a convenience during
+# development time, only. Configurations set by this file require interctive
+# confirmation from the current user and are scoped to the current directory.
+# More info at (https://direnv.net/man/direnv-stdlib.1.html)
+set -e
+# Loads a ".env" file into the current environment
+# dotenv .env
+# Loads NodeJS version from a .node-version or .nvmrc file.
+use nvm
+# Adds "$PWD/node_modules/.bin" to the PATH environment variable
+layout node

--- a/.gitignore
+++ b/.gitignore
@@ -68,8 +68,9 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variables file
+# environment variables file
 .env
+.envrc
 .env.test
 
 # parcel-bundler cache (https://parceljs.org/)

--- a/.gitignore
+++ b/.gitignore
@@ -73,9 +73,8 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
-# environment variables file
+# dotenv environment variables file
 .env
-.envrc
 .env.test
 
 # parcel-bundler cache (https://parceljs.org/)

--- a/.npmignore
+++ b/.npmignore
@@ -73,8 +73,9 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variables file
+# environment variables file
 .env
+.envrc
 .env.test
 
 # parcel-bundler cache (https://parceljs.org/)

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'airbnb-base',
+    'prettier',
   ],
   plugins: [
     '@typescript-eslint',
@@ -18,24 +19,34 @@ module.exports = {
     "no-redeclare": "off",
     "@typescript-eslint/no-redeclare": ["error"],
     "indent": "off",
-    "@typescript-eslint/indent": ["error", 2],
     "no-use-before-define": "off",
     "@typescript-eslint/no-use-before-define": ["error"],
     'no-unused-vars': 'off',
     'import/prefer-default-export': 'off',
     'import/extensions': 'off',
     'import/no-unresolved': 'off',
-    'max-len': [
-      'warn', // TODO: This should be 'error'
-      {
-        code: 120,
-        ignoreComments: true,
-        ignoreTrailingComments: true,
-        ignoreStrings: true,
-      },
-    ],
     'import/no-extraneous-dependencies': ['error', { 'devDependencies': ['**/*.test.ts', '**/*.spec.ts'] }],
     '@typescript-eslint/no-namespace': 'off',
+
+    'curly': ['error', 'all'],
+    'no-tabs': ['error', { 'allowIndentationTabs': true }],
+    'max-len': ['error', {
+      'code': 120,
+      'ignoreUrls': true,
+      'ignoreComments': true,
+      'ignoreTrailingComments': true,
+      'ignoreStrings': true,
+      'ignoreRegExpLiterals': true,
+      'ignoreTemplateLiterals': true,
+    }],
+    'quotes': [
+      'error',
+      'single',
+      { 'avoidEscape': true, 'allowTemplateLiterals': false }
+    ],
+    'wrap-iife': ['error', 'inside'],
+    '@typescript-eslint/indent': 'off',
+    'no-mixed-operators': 'off',
 
     // TODO: Create tickets and check each rule
     "@typescript-eslint/no-use-before-define": ["warn"],
@@ -45,7 +56,6 @@ module.exports = {
     'prefer-destructuring': 'warn',
     'radix': 'warn',
     'global-require': 'warn',
-    'no-mixed-operators': 'warn',
     'no-return-assign': 'warn',
     'no-multi-str': 'warn',
     'no-unused-expressions': 'warn',
@@ -67,7 +77,6 @@ module.exports = {
     'guard-for-in': 'warn',
     'array-callback-return': 'warn',
     'no-plusplus': 'warn',
-    'no-tabs': 'warn',
     'no-param-reassign': 'warn',
     'camelcase': 'warn',
     'import/no-dynamic-require': ['warn'],

--- a/index.js
+++ b/index.js
@@ -16,11 +16,11 @@ module.exports = {
   rules: {
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': ['error'],
-    "no-redeclare": "off",
-    "@typescript-eslint/no-redeclare": ["error"],
-    "indent": "off",
-    "no-use-before-define": "off",
-    "@typescript-eslint/no-use-before-define": ["error"],
+    'no-redeclare': 'off',
+    '@typescript-eslint/no-redeclare': ['error'],
+    'indent': 'off',
+    'no-use-before-define': 'off',
+    '@typescript-eslint/no-use-before-define': ['error'],
     'no-unused-vars': 'off',
     'import/prefer-default-export': 'off',
     'import/extensions': 'off',
@@ -49,7 +49,7 @@ module.exports = {
     'no-mixed-operators': 'off',
 
     // TODO: Create tickets and check each rule
-    "@typescript-eslint/no-use-before-define": ["warn"],
+    '@typescript-eslint/no-use-before-define': ['warn'],
     'no-useless-constructor': 'warn',
     'no-bitwise': 'warn',
     'no-buffer-constructor': 'warn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@mobietrain/eslint-config",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mobietrain/eslint-config",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "4.33.0",
         "@typescript-eslint/parser": "4.33.0",
         "eslint-config-airbnb-base": "14.2.1",
+        "eslint-config-prettier": "8.5.0",
         "eslint-config-react-app": "6.0.0",
         "eslint-plugin-import": "2.26.0"
       },
@@ -1168,6 +1169,17 @@
       "peerDependencies": {
         "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
         "eslint-plugin-import": "^2.22.1"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-config-react-app": {
@@ -3964,6 +3976,12 @@
         "object.assign": "^4.1.2",
         "object.entries": "^1.1.2"
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "requires": {}
     },
     "eslint-config-react-app": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobietrain/eslint-config",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Sharable eslint configuration",
   "main": "index.js",
   "scripts": {
@@ -15,6 +15,7 @@
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",
     "eslint-config-airbnb-base": "14.2.1",
+    "eslint-config-prettier": "8.5.0",
     "eslint-config-react-app": "6.0.0",
     "eslint-plugin-import": "2.26.0"
   },

--- a/react-app.js
+++ b/react-app.js
@@ -4,5 +4,6 @@ module.exports = {
   ],
   rules: {
     'react/jsx-pascal-case': ['error', { allowNamespace: true }],
+    'no-mixed-operators': 'off',
   }
 }


### PR DESCRIPTION
[MT-6078](https://mobietrain-app.atlassian.net/browse/MT-6078)

(Subtask of [MT-6044](https://mobietrain-app.atlassian.net/browse/MT-6044))

- Installing `eslint-config-prettier` package and using it on `index.js` to extend our rules.
- The other rules added are mostly kind of moved from CMS, APP and API to this project because they are being used in the 3 projects.
- `@typescript-eslint/indent` is turned off because it can conflict with Prettier.
- `no-mixed-operators` is also turned off because it can conflict with Prettier, but I added it on both `index.js` and `react-app.js` because the first file is enough for the API, but for the frontend projects since we extend also `react-app` the rule is again introduced by `eslint-config-react-app` ([here](https://www.npmjs.com/package/eslint-config-react-app/v/6.0.0?activeTab=explore)).
- I also thought about extending `react-app.js` rules with `prettier` but for now it seems unnecessary as no conflicts seem to exist.

Note: I added the `.envrc` file because since we have a `.npmrc` defining the node version this can help us to change the version we're using. However, I commented the line `dotenv .env` because currently we don't have any `.env` file.