### PR TITLE
chore(linter-rules): enable eslint rule 'jsx-a11y/alt-text' [MT-6235]

### DIFF
--- a/react-app.js
+++ b/react-app.js
@@ -5,5 +5,9 @@ module.exports = {
   rules: {
     'react/jsx-pascal-case': ['error', { allowNamespace: true }],
     'no-mixed-operators': 'off',
+    'jsx-a11y/alt-text': [ 2, {
+      'elements': [ 'img', 'object', 'area', 'input[type=\"image\"]' ],
+      'img': ['Media', 'animated.img'],
+    }],
   }
 }


### PR DESCRIPTION
[MT-6235]

Enable [this rule](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/alt-text.md) for react apps to improve accessibility.